### PR TITLE
Add data items to record in order of FRN (encoder) and use same order in decoder

### DIFF
--- a/asterix.py
+++ b/asterix.py
@@ -129,7 +129,7 @@ def encode_category(cat, did, tree):
 
     datarecord = 0L
     n_octets_datarecord = 0
-    sorted_mdi_keys = sorted(mdi.keys())
+    sorted_mdi_keys = sorted_by_frn(mdi.keys(), tree)
     for di in sorted_mdi_keys:
         l, v = mdi[di]
         datarecord <<= l*8
@@ -399,7 +399,7 @@ def decode_record(stream):
     # decode dataitems
     results = {}
     length = 0
-    for di in sorted(dis):
+    for di in sorted_by_frn(dis, tree):
         if verbose >= 1:
             print 'decoding dataitem',di
         l, r = decode_datafield(stream, di, tree)
@@ -573,3 +573,10 @@ def tofile(x, filename):
         fp.close()
     except Exception, e:
         print str(e)
+
+
+def sorted_by_frn(items_list, xml_tree):
+    uap_items = xml_tree.getElementsByTagName('UAP')[0].getElementsByTagName('UAPItem')
+    item_to_frn = {i.firstChild.nodeValue: i.getAttribute('frn') for i in uap_items}
+    item_to_frn = {int(k): int(v) for k, v in item_to_frn.items() if k.isdigit() and v.isdigit()}
+    return sorted(items_list, key=lambda i: item_to_frn[i])


### PR DESCRIPTION
`sortedn(mdi.keys())` sort items based on data item number, while items should add in order of their FRN.

For example here if we sort based on data item numbers, it will be `10, 30, 40, 80, 130` but the right order is `10, 40, 30, 130, 80`.

```
<UAPItem bit="0" frn="1" len="2">010</UAPItem>
<UAPItem bit="1" frn="2" len="2">040</UAPItem>
<UAPItem bit="2" frn="3" len="3">030</UAPItem>
<UAPItem bit="3" frn="4" len="6">130</UAPItem>
<UAPItem bit="4" frn="5" len="3">080</UAPItem>
```
